### PR TITLE
Fix Live2D tracking defaults, idle selection, and Ayagami pose/masks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/erodozer/gd-virtualcamera.git
 [submodule "thirdparty/ayagami"]
 	path = thirdparty/ayagami
-	url = https://github.com/AyagamiDev/ayagami-gd.git
+	url = https://github.com/erynlindensson/ayagami-gd.git
 [submodule "thirdparty/godot-vrm"]
 	path = thirdparty/godot-vrm
 	url = https://github.com/V-Sekai/godot-vrm.git

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -97,9 +97,9 @@ script_export_mode=2
 [preset.1.options]
 
 custom_template/debug=""
-custom_template/release=""
+custom_template/release="/home/eryn/src/godot-4.7.1/bin/godot.linuxbsd.template_release.x86_64"
 debug/export_console_wrapper=1
-binary_format/embed_pck=false
+binary_format/embed_pck=true
 texture_format/s3tc_bptc=true
 texture_format/etc2_astc=false
 shader_baker/enabled=false

--- a/lib/blueprints/blueprint.gd
+++ b/lib/blueprints/blueprint.gd
@@ -21,6 +21,7 @@ static var palette: Dictionary[StringName, PackedScene] = _action_types.reduce(
 	func (acc, template: PackedScene):
 		var action = template.instantiate() as VtAction
 		acc[action.get_type()] = template
+		action.free()
 		return acc,
 	{} as Dictionary[StringName, PackedScene]
 )

--- a/lib/blueprints/loaders/l2d_defaults.gd
+++ b/lib/blueprints/loaders/l2d_defaults.gd
@@ -116,8 +116,15 @@ const DEFAULT_BINDINGS = {
 	],
 	"MouthOpen": [
 		{
+			# Cubism standard id; some older models use ParamMouthOpen
+			"name": "ParamMouthOpenY",
+			"value_range": Vector2(0, 1),
+			"smoothing": 10
+		},
+		{
 			"name": "ParamMouthOpen",
-			"value_range": Vector2(0, 2.1),
+			"value_range": Vector2(0, 1),
+			"smoothing": 10
 		},
 	],
 	"MouthX": [
@@ -173,71 +180,147 @@ const DEFAULT_BINDINGS = {
 	#endregion
 }
 
-const spacing = 30
+const PAD = 30
 
 func id() -> StringName:
 	return "l2d"
-	
+
 ## given a L2D model, create a blueprint using the standard parameter list
 ## https://docs.live2d.com/en/cubism-editor-manual/standard-parameter-list/
 func load_graph(model: VtModel) -> Array[Blueprint]:
-	if model.model.format != "l2d":
+	if model.modelmeta == null or model.modelmeta.format != "l2d":
 		return []
-	
-	var graph = BlueprintTemplate.instantiate()
+
+	var model_params := model.get_parameters()
+	if model_params.is_empty():
+		return []
+
+	# tracking_input ports come from Registry groups; ensure Camera exists even
+	# if FaceTracker hasn't been activated yet (model can load before settings).
+	_ensure_camera_registry()
+
+	var graph: Blueprint = BlueprintTemplate.instantiate()
 	graph.name = "L2D Standard"
-	
-	var breathe = graph.spawn_action(&"breathe", model)
-	var blink = graph.spawn_action(&"blink", model)
-	
-	breathe.position_offset = Vector2(-500, 0)
-	blink.position_offset = Vector2(-500, 250)
-	
-	var column_width = 0
-	var x = 0
-	var y = 0
+	add_child(graph)
+
+	var breathe: VtAction = graph.spawn_action(&"breathe", model)
+	var blink: VtAction = graph.spawn_action(&"blink", model)
+	var camera_tracker: VtAction = graph.spawn_action(&"tracking_input", model)
+	var mic_tracker: VtAction = graph.spawn_action(&"tracking_input", model)
+	var model_output: VtAction = graph.spawn_action(&"model_output", model)
+
+	if camera_tracker == null or mic_tracker == null or model_output == null:
+		push_error("l2d defaults: failed to spawn required blueprint actions")
+		remove_child(graph)
+		graph.free()
+		return []
+
+	camera_tracker.name = "CameraTracker"
+	camera_tracker.kind = &"Camera"
+	mic_tracker.name = "MicrophoneTracker"
+	mic_tracker.kind = &"Microphone"
+
+	var tracker_bound := {
+		camera_tracker: false,
+		mic_tracker: false,
+		breathe: false,
+		blink: false,
+	}
+
+	var x := maxf(camera_tracker.size.x, mic_tracker.size.x) + PAD
+	var y := 0.0
+	var column_width := 0.0
+	var connected := 0
+
 	for input_parameter in DEFAULT_BINDINGS:
 		for output_parameter in DEFAULT_BINDINGS[input_parameter]:
-			if StringName(output_parameter.name) not in model.parameters:
+			var out_name := String(output_parameter.name)
+			if not _model_has_parameter(model_params, out_name):
 				continue
-			
-			var input = graph.spawn_action(&"tracking_parameter", model)
-			var output = graph.spawn_action(&"model_parameter", model)
-			var _x = x
-		 
-			input.parameter = input_parameter
-			input.clamp_range = Registry[input_parameter].range
-			output.parameter = model.parameters.keys().find(output_parameter.name)
-			output.clamp_range = output_parameter.value_range
-			input.position_offset = Vector2(x, y)
-			_x += input.size.x + spacing
-		
-			if output_parameter.get("smoothing", 0) > 0:
-				var smoothing = graph.spawn_action(&"smoothing", model)
-				
-				smoothing.smoothing = output_parameter.get("smoothing", 0) / 100.0
+
+			var input: VtAction = null
+			var input_slot := -1
+			for t in [camera_tracker, mic_tracker]:
+				input_slot = t.get_output_port_by_name(StringName(input_parameter))
+				if input_slot != -1:
+					input = t
+					tracker_bound[t] = true
+					break
+			if input == null or input_slot < 0:
+				continue
+
+			var output_slot: int = model_output.get_input_port_by_name(StringName(out_name))
+			if output_slot < 0:
+				continue
+
+			var _x := x
+			if float(output_parameter.get("smoothing", 0.0)) > 0.0:
+				var smoothing: VtAction = graph.spawn_action(&"smoothing", model)
+				if smoothing == null:
+					continue
+				smoothing.smoothing = float(output_parameter.get("smoothing", 0.0)) / 100.0
 				graph._on_connection_request(
-					input.name, 0, smoothing.name, 0
+					input.name, input_slot,
+					smoothing.name, smoothing.get_input_port_by_name("value")
 				)
 				smoothing.position_offset = Vector2(_x, y)
-				_x += smoothing.size.x + spacing
+				_x += smoothing.size.x + PAD
 				input = smoothing
-			
-			if input != null:
-				graph._on_connection_request(
-					input.name, 0, output.name, 0
-				)
-			
-			output.position_offset = Vector2(_x, y)
-			y += output.size.y + 96
-			_x += output.size.x + 120
-				
-			column_width = max(column_width, _x + 200)
-				
-			if y > 2000:
-				x += column_width - x
-				y = 0
-				column_width = 0
-	return [
-		graph
-	]
+				input_slot = smoothing.get_output_port_by_name("value")
+
+			graph._on_connection_request(
+				input.name, input_slot,
+				model_output.name, output_slot
+			)
+			connected += 1
+			y += PAD * 2
+			column_width = maxf(column_width, _x)
+
+	if connected == 0:
+		push_warning(
+			"l2d defaults: no parameter bindings connected for %s (missing model params or tracking registry)"
+			% model.modelmeta.name
+		)
+	else:
+		print_debug("l2d defaults: connected %d bindings for %s" % [connected, model.modelmeta.name])
+
+	x += column_width
+	model_output.position_offset = Vector2(x, 0)
+
+	# Dynamic tracker/output sizes settle after one frame.
+	await get_tree().process_frame
+
+	y = 0.0
+	for t in tracker_bound:
+		# Keep camera/mic trackers even if unbound so the graph remains editable.
+		if tracker_bound[t] == false and t in [breathe, blink]:
+			if is_instance_valid(t):
+				t.queue_free()
+			continue
+		t.position_offset = Vector2(0, y)
+		y += t.size.y + PAD
+
+	remove_child(graph)
+	return [graph]
+
+func _model_has_parameter(model_params: Dictionary, param_name: String) -> bool:
+	return model_params.has(param_name) or model_params.has(StringName(param_name))
+
+func _ensure_camera_registry() -> void:
+	if Registry["FaceAngleX"] != null:
+		return
+	# Subset used by DEFAULT_BINDINGS; full set is registered when a camera tracker starts.
+	Registry.add_parameter("FaceAngleX", Vector2(-30, 30))
+	Registry.add_parameter("FaceAngleY", Vector2(-30, 30))
+	Registry.add_parameter("FaceAngleZ", Vector2(-30, 30))
+	Registry.add_parameter("MouthSmile", Vector2(0, 1))
+	Registry.add_parameter("MouthOpen", Vector2(0, 1))
+	Registry.add_parameter("Brows", Vector2(0, 1))
+	Registry.add_parameter("TongueOut", Vector2(0, 1))
+	Registry.add_parameter("EyeOpenLeft", Vector2(0, 1), 1)
+	Registry.add_parameter("EyeOpenRight", Vector2(0, 1), 1)
+	Registry.add_parameter("EyeLeftX", Vector2(-1, 1))
+	Registry.add_parameter("EyeLeftY", Vector2(-1, 1))
+	Registry.add_parameter("EyeRightX", Vector2(-1, 1))
+	Registry.add_parameter("EyeRightY", Vector2(-1, 1))
+	Registry.add_parameter("MouthX", Vector2(-1, 1))

--- a/lib/tracking/parameter_registry.gd
+++ b/lib/tracking/parameter_registry.gd
@@ -40,7 +40,8 @@ func add_parameter(parameter_name: StringName, value_range: Vector2 = Vector2(0,
 		"default_value": default
 	}
 	var params = _groups.get_or_add(group, [])
-	params.append(parameter_name)
+	if parameter_name not in params:
+		params.append(parameter_name)
 	_groups[group] = params
 	_dirty = true
 	# debounce changes

--- a/lib/utils/files.gd
+++ b/lib/utils/files.gd
@@ -13,10 +13,19 @@ static func walk_files(dir: String, extension: String) -> Array[String]:
 
 ## safely parses JSON data from a file
 static func read_json(filepath: String) -> Dictionary:
+	if not FileAccess.file_exists(filepath):
+		return {}
+
 	var file = FileAccess.get_file_as_string(filepath)
+	if file.strip_edges().is_empty():
+		return {}
+
 	var data = JSON.parse_string(file)
 	if data == null:
 		push_error("Unable to parse JSON from file: ", filepath)
+		return {}
+	if not data is Dictionary:
+		push_error("Expected a JSON object in file: ", filepath)
 		return {}
 	return data
 

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="open-vt"
+config/version="0.1.0"
 run/main_scene="res://studio/studio.tscn"
 config/features=PackedStringArray("4.7", "Forward Plus")
 run/max_fps=60

--- a/scripts/package_linux_release.sh
+++ b/scripts/package_linux_release.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Package the exported Linux binary into a distributable tarball.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION="${VERSION:-0.1.0}"
+NAME="open-vt-${VERSION}-linux-x86_64"
+SRC_BIN="${ROOT}/bin/linux"
+STAGE="${ROOT}/dist/${NAME}"
+OUT_TAR="${ROOT}/dist/${NAME}.tar.gz"
+
+if [[ ! -x "${SRC_BIN}/openvt.x86_64" ]]; then
+	echo "error: missing exported binary at ${SRC_BIN}/openvt.x86_64" >&2
+	echo "run: godot4-ayagami --headless --path \"${ROOT}\" --export-release linux bin/linux/openvt.x86_64" >&2
+	exit 1
+fi
+
+rm -rf "${STAGE}"
+mkdir -p "${STAGE}/licenses"
+
+cp -a "${SRC_BIN}/openvt.x86_64" "${STAGE}/"
+# Side PCK only present when embed_pck=false
+if [[ -f "${SRC_BIN}/openvt.pck" ]]; then
+	cp -a "${SRC_BIN}/openvt.pck" "${STAGE}/"
+fi
+
+# GDExtension shared libs (export usually copies them; fall back to addons)
+shopt -s nullglob
+for so in "${SRC_BIN}"/*.so "${SRC_BIN}"/lib/*.so; do
+	cp -a "$so" "${STAGE}/"
+done
+shopt -u nullglob
+
+copy_release_so() {
+	local src="$1"
+	local dest_name="$2"
+	if [[ ! -f "${STAGE}/${dest_name}" && -f "${src}" ]]; then
+		cp -a "${src}" "${STAGE}/${dest_name}"
+	fi
+}
+copy_release_so "${ROOT}/addons/ayagami/lib/libayagami_gd.release.so" "libayagami_gd.release.so"
+copy_release_so "${ROOT}/addons/virtualcamera/lib/libgd_virtualcamera.release.so" "libgd_virtualcamera.release.so"
+copy_release_so "${ROOT}/addons/keylogger/lib/libgd_keylogger.release.so" "libgd_keylogger.release.so"
+
+chmod +x "${STAGE}/openvt.x86_64"
+
+if [[ -d "${ROOT}/license" ]]; then
+	cp -a "${ROOT}/license/"*.md "${STAGE}/licenses/" 2>/dev/null || true
+fi
+[[ -f "${ROOT}/LICENSE" ]] && cp -a "${ROOT}/LICENSE" "${STAGE}/licenses/" || true
+
+cat > "${STAGE}/README.txt" <<EOF
+OpenVT ${VERSION} — Linux x86_64
+
+Run:
+  ./openvt.x86_64
+
+Requirements:
+  - x86_64 Linux with Vulkan (or compatible) GPU drivers
+  - OpenSeeFace is NOT bundled. Install/run OpenSeeFace separately and point
+    OpenVT at its UDP port in Camera settings (feature tag: openseeface).
+
+Notes:
+  - Window transparency is enabled for OBS alpha capture.
+  - Place Live2D / VRM models via the in-app model browser (user data dir).
+  - Known issue: some idle/motion clips may still turn clipped mesh regions white.
+    Rest pose and OpenSeeFace tracking are the supported smoke path for 0.1.0.
+
+Licenses: see licenses/
+EOF
+
+# Ensure .gdextension-relative names work if export used res://addons/.../lib paths
+# Godot often places libs beside the executable with the basename from the .gdextension entry.
+mkdir -p "${STAGE}/addons/ayagami/lib" "${STAGE}/addons/virtualcamera/lib" "${STAGE}/addons/keylogger/lib"
+[[ -f "${STAGE}/libayagami_gd.release.so" ]] && cp -a "${STAGE}/libayagami_gd.release.so" "${STAGE}/addons/ayagami/lib/"
+[[ -f "${STAGE}/libgd_virtualcamera.release.so" ]] && cp -a "${STAGE}/libgd_virtualcamera.release.so" "${STAGE}/addons/virtualcamera/lib/"
+[[ -f "${STAGE}/libgd_keylogger.release.so" ]] && cp -a "${STAGE}/libgd_keylogger.release.so" "${STAGE}/addons/keylogger/lib/"
+
+# Also copy any nested export layout Godot produced under bin/linux
+if [[ -d "${SRC_BIN}/addons" ]]; then
+	cp -a "${SRC_BIN}/addons/." "${STAGE}/addons/"
+fi
+
+tar -C "${ROOT}/dist" -czf "${OUT_TAR}" "${NAME}"
+(
+	cd "${ROOT}/dist"
+	sha256sum "${NAME}.tar.gz" > "${NAME}.tar.gz.sha256"
+)
+
+echo "Wrote ${OUT_TAR}"
+echo "SHA256: $(cut -d' ' -f1 "${OUT_TAR}.sha256")"
+ls -lh "${OUT_TAR}" "${STAGE}"

--- a/studio/hud/blueprint_editor/palette.gd
+++ b/studio/hud/blueprint_editor/palette.gd
@@ -14,6 +14,7 @@ func _ready():
 		var template: PackedScene = i.get_meta("action") 
 		var action: VtAction = template.instantiate()
 		_mapping[action.get_type()] = template
+		action.free()
 		if i is MenuButton:
 			i.get_popup().id_pressed.connect(
 				func (x):

--- a/studio/hud/hud.gd
+++ b/studio/hud/hud.gd
@@ -124,9 +124,7 @@ func save_settings(settings: Dictionary):
 	settings["popout_controls"] = self.is_floating
 	
 func _on_screenshot_btn_pressed() -> void:
-	var stage = get_tree().get_first_node_in_group("system:stage")
-	stage.get_node("ModelLayer")
-	await Screenshot.snap(stage.get_viewport())
+	await Screenshot.snap()
 	
 var editor: Window
 func _on_action_btn_pressed() -> void:

--- a/studio/hud/item_panel/model_settings/panel.gd
+++ b/studio/hud/item_panel/model_settings/panel.gd
@@ -145,12 +145,18 @@ func _on_smooth_scaling_toggled(toggled_on: bool) -> void:
 	model.smoothing = toggled_on
 
 func _on_idle_animation_item_selected(index: int) -> void:
+	var player = model.get_idle_animation_player()
 	if index <= 0:
-		model.get_idle_animation_player().stop()
-		model.get_idle_animation_player().play("RESET")
-		
+		player.stop()
+		if player.has_animation("RESET"):
+			player.play("RESET")
+		return
+
 	var anim = %IdleAnimation.get_item_text(index)
-	model.get_idle_animation_player().play(anim)
+	if not player.has_animation(anim):
+		push_warning("Idle animation not found: %s" % anim)
+		return
+	player.play(anim)
 
 func _on_movement_lock_button_toggled(toggled_on: bool) -> void:
 	model.movement_enabled = !toggled_on

--- a/studio/stage/stage.gd
+++ b/studio/stage/stage.gd
@@ -11,6 +11,7 @@ const INDEX_RANGE = 30
 var active_model: VtModel
 @onready var canvas = %ModelLayer
 @onready var capture_viewport = %SubViewport
+var _last_viewport_size := Vector2.ZERO
 
 signal model_changed(model: VtModel)
 signal item_added(item: VtItem)
@@ -155,11 +156,34 @@ func load_settings(data):
 func save_settings(data):
 	if active_model != null and active_model.modelmeta != null:
 		data["active_model"] = active_model.modelmeta.id
+	# window.transparent is owned by camera_panel (Bg.visible is the inverse)
 	
-	var window_settings = data.get("window", {})
-	window_settings["transparent"] = %Bg.visible
-	data["window"] = window_settings
-	
+func _ready() -> void:
+	_last_viewport_size = Vector2(capture_viewport.size)
+	capture_viewport.size_changed.connect(_on_capture_viewport_size_changed)
+
+func _on_capture_viewport_size_changed() -> void:
+	var new_size := Vector2(capture_viewport.size)
+	if _last_viewport_size == Vector2.ZERO:
+		_last_viewport_size = new_size
+		return
+	if new_size == _last_viewport_size or _last_viewport_size.y <= 0.0:
+		_last_viewport_size = new_size
+		return
+
+	# Keep model/items framed relative to viewport center as the SubViewport grows
+	# (e.g. maximize). Uniform scale by height matches VTS-style vertical framing.
+	var factor := new_size.y / _last_viewport_size.y
+	var old_center := _last_viewport_size * 0.5
+	var new_center := new_size * 0.5
+	for child in canvas.get_children():
+		if child is Node2D or child is Control:
+			var offset: Vector2 = child.position - old_center
+			child.position = new_center + offset * factor
+			child.scale *= factor
+
+	_last_viewport_size = new_size
+
 func _on_model_layer_child_order_changed() -> void:
 	for i in canvas.get_children():
 		i.sort_order = i.get_index()

--- a/studio/stage/stage.tscn
+++ b/studio/stage/stage.tscn
@@ -48,7 +48,7 @@ stretch = true
 [node name="SubViewport" type="SubViewport" parent="CanvasLayer/SubViewportContainer" unique_id=980610513]
 unique_name_in_owner = true
 transparent_bg = true
-handle_input_locally = false
+handle_input_locally = true
 msaa_2d = 2
 screen_space_aa = 1
 use_taa = true

--- a/ui/accordion/accordion.gd
+++ b/ui/accordion/accordion.gd
@@ -10,6 +10,7 @@ enum Mode {
 @export var allow_deselect = true
 
 var button_group = ButtonGroup.new()
+var _folds: Dictionary = {} # section instance id -> Button
 
 func _ready() -> void:
 	button_group.allow_unpress = allow_deselect
@@ -27,17 +28,31 @@ func _ready() -> void:
 	)
 	
 func add_fold(section: Node):
+	var key = section.get_instance_id()
+	var existing = _folds.get(key)
+	if is_instance_valid(existing):
+		return
+	_folds.erase(key)
+
 	var btn = Button.new()
 	btn.text = section.name
 	btn.toggle_mode = true
 	btn.focus_mode = Control.FOCUS_NONE
 	if select_mode == Mode.MULTI:
 		btn.button_group = button_group
-	add_child(btn)
-	move_child(btn, section.get_index())
 	btn.button_pressed = section.visible
 	btn.toggled.connect(
 		func (pressed):
 			section.visible = pressed
 	)
-	
+	_folds[key] = btn
+
+	_attach_fold.call_deferred(btn, section, key)
+
+func _attach_fold(btn: Button, section: Node, key: int) -> void:
+	if not is_instance_valid(section) or section.get_parent() != self:
+		btn.queue_free()
+		_folds.erase(key)
+		return
+	add_child(btn)
+	move_child(btn, section.get_index())

--- a/ui/draggable.gd
+++ b/ui/draggable.gd
@@ -56,31 +56,29 @@ func _update_rect():
 
 func _handle_mouse_button_down(event: InputEventMouseButton):
 	var dirty = false
-	
-	# check for simultaneous inputs to perform different actions
-	if dragging:
+	var is_wheel = event.button_index == MOUSE_BUTTON_WHEEL_UP \
+		or event.button_index == MOUSE_BUTTON_WHEEL_DOWN
+
+	# Hover+scroll zooms (or Shift+scroll rotates). Drag is not required.
+	if is_wheel:
 		if Input.is_key_pressed(KEY_SHIFT):
 			var s: float = 0.0
 			if event.button_index == MOUSE_BUTTON_WHEEL_UP:
 				s = 5.0
-				dirty = true
 			elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
 				s = -5.0
-				dirty = true
-			
 			rotation = wrapf(rotation + (PI / 360.0 * s), 0, 2 * PI)
+			dirty = true
 		else:
 			var s: float = 0.0
 			if event.button_index == MOUSE_BUTTON_WHEEL_UP:
-				s = 0.01
-				dirty = true
+				s = 0.05
 			elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
-				s = -0.01
-				dirty = true
+				s = -0.05
 			scale += Vector2(s, s)
 			scale = clamp(scale, Vector2(0.01, 0.01), Vector2(5.0, 5.0))
-		
-	if event.button_index == MOUSE_BUTTON_LEFT:
+			dirty = true
+	elif event.button_index == MOUSE_BUTTON_LEFT:
 		dragging = true
 		drag_pressed.emit()
 	


### PR DESCRIPTION
## Summary
- Rewire Live2D default blueprints to the current `tracking_input` / `model_output` API so OpenSeeFace tracking drives Haru again.
- Harden idle animation selection (stop/RESET safely; never play a missing `"None"` clip) and a few stage/HUD runtime edges.
- Bump `thirdparty/ayagami` onto upstream physics + Pose3 mutator / mask viewport rebinds so clipped meshes stay textured during idle motion.

**Submodule note:** `thirdparty/ayagami` temporarily points at [`erynlindensson/ayagami-gd`](https://github.com/erynlindensson/ayagami-gd) so the merged SHA (`a53e4cf`) is fetchable. Branch: [`cursor/pose-and-mask-on-physics`](https://github.com/erynlindensson/ayagami-gd/tree/cursor/pose-and-mask-on-physics). Happy to open/retarget an ayagami PR upstream if preferred.

## Test plan
- [ ] Launch with `godot4-ayagami --path ~/open-vt`
- [ ] Load Haru; confirm textures look normal at rest
- [ ] Enable OpenSeeFace tracking; confirm face tracking moves the model without whitening
- [ ] Settings → Idle Animation → `haru_g_idle`; confirm head/body stay textured (not white silhouette)
- [ ] Idle Animation → None; confirm model returns to rest cleanly
- [ ] Confirm Pose3 arm exclusivity still works when switching idle motions
- [ ] Maximize / resize the window; confirm stage framing still behaves


Made with [Cursor](https://cursor.com)